### PR TITLE
Feature/fix database setting #5

### DIFF
--- a/api/config/database.yml
+++ b/api/config/database.yml
@@ -19,7 +19,7 @@ default: &default
 
 development:
   <<: *default
-  database: sample
+  database: todo_app_db
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".

--- a/api/config/database.yml
+++ b/api/config/database.yml
@@ -14,8 +14,8 @@ default: &default
   encoding: utf8mb4
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
-  password: 
-  host: locaohost
+  password: password
+  host: db
 
 development:
   <<: *default

--- a/api/config/environments/development.rb
+++ b/api/config/environments/development.rb
@@ -50,5 +50,5 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
   # host を docker コンテナの名前に合わせる
-  config.hosts = "api"
+  config.hosts << "api"
 end

--- a/api/config/environments/development.rb
+++ b/api/config/environments/development.rb
@@ -49,4 +49,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  # host を docker コンテナの名前に合わせる
+  config.hosts = "api"
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,12 @@ version: '3.7'
 services: 
   db:
     image: mysql:8.0
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    command: --default-authentication-plugin=mysql_native_password
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: sample
       MYSQL_PASSWORD: password
+      host: db
     ports:
       - 3306:3306
     volumes:
@@ -32,7 +33,7 @@ services:
       - ./front/app:/usr/src/app
     command: 'yarn dev'
     ports:
-      - "8000:8000"
+      - "8000:3000"
 volumes:
   mysql-db:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: todo_app_db
       MYSQL_PASSWORD: password
-      host: db
     ports:
       - 3306:3306
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.7'
 services: 
   db:
     image: mysql:8.0
-    command: --default-authentication-plugin=mysql_native_password
+    command: --collation-server=utf8mb4_general_ci --default-authentication-plugin=mysql_native_password
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: todo_app_db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     command: --default-authentication-plugin=mysql_native_password
     environment:
       MYSQL_ROOT_PASSWORD: password
-      MYSQL_DATABASE: sample
+      MYSQL_DATABASE: todo_app_db
       MYSQL_PASSWORD: password
       host: db
     ports:


### PR DESCRIPTION
## 対応step
[step5: データベースの接続設定（周辺設定）](https://github.com/KentaroYamada91011/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%975-%E3%83%87%E3%83%BC%E3%82%BF%E3%83%99%E3%83%BC%E3%82%B9%E3%81%AE%E6%8E%A5%E7%B6%9A%E8%A8%AD%E5%AE%9A%E5%91%A8%E8%BE%BA%E8%A8%AD%E5%AE%9A%E3%82%92%E3%81%97%E3%81%BE%E3%81%97%E3%82%87%E3%81%86)

## 技術構成
- Docker
- Rails( api mode )
- Next.js
を使用している。

### バージョン
Ruby 3.0.1
Rails 6.0.3.7
MySQL 8.0

## 前提
https://zenn.dev/taku1115/articles/6c9fa97ab37e38
こちらの記事を参考に、Rails api mode + Next.js + Docker でアプリケーション作成

設計についてはこちら #4 

## 修正内容
database部分の修正commit
 - docker-compose file で mysql のユーザー作成
 - database.yml でログインするユーザーの設定
 - mysql と接続する host の修正
 - MySQL 8.0のため、以下のcommandで起動
 ```
command: --default-authentication-plugin=mysql_native_password
```
[こちらの記事を参考にしました](https://keruuweb.com/docker-mysql8%E3%81%A7%E8%AA%8D%E8%A8%BC%E9%96%A2%E9%80%A3%E3%81%AE%E3%82%A8%E3%83%A9%E3%83%BC%E3%81%8C%E7%99%BA%E7%94%9F%E3%81%97%E3%81%9F%E3%81%AE%E3%81%A7%E3%81%9D%E3%81%AE%E5%AF%BE%E7%AD%96/)

## 手元での確認方法

```
$ docker-compose up --build
$ docker container ls
## apiのリポジトリに入る
$ docker exec -i -t <api の docker のコンテナid> bash
## rails の db 作成
> rails db:create
## mysqlにログイン
> mysql -uroot -h db -p
Enter password: password
```
ログイン、データベース作成ができることが確認できる