### PR TITLE
Feature/add application setting #step9

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -48,3 +48,4 @@ gem 'rubocop-rails', require: false
 gem 'rack-cors'
 
 gem "webrick", "~> 1.7"
+gem 'rails-i18n'

--- a/api/Gemfile
+++ b/api/Gemfile
@@ -47,5 +47,5 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'rubocop-rails', require: false
 gem 'rack-cors'
 
-gem "webrick", "~> 1.7"
+gem 'webrick', '~> 1.7'
 gem 'rails-i18n'

--- a/api/app/controllers/api/tasks_controller.rb
+++ b/api/app/controllers/api/tasks_controller.rb
@@ -9,21 +9,21 @@ module Api
 
     def create
       task = Task.create!(task_param)
-      render json: { status: 'SUCCESS', message: I18n.t(:create_the_task), data: task }
+      render json: { status: 'SUCCESS', message: I18n.t("errors.create_the_task"), data: task }
     rescue ActiveRecord::RecordInvalid => e
       render json: { status: 'ERROR', message: e }
     end
 
     def destroy
       @task.destroy
-      render json: { status: 'SUCCESS', message: I18n.t(:delete_the_task), data: @task }
+      render json: { status: 'SUCCESS', message: I18n.t("errors.delete_the_task"), data: @task }
     rescue ActiveRecord::RecordInvalid => e
       render json: { status: 'ERROR', message: e }
     end
 
     def update
       @task.update!(task_param)
-      render json: { status: 'SUCCESS', message: I18n.t(:update_the_task), data: @task }
+      render json: { status: 'SUCCESS', message: I18n.t("errors.update_the_task"), data: @task }
     rescue ActiveRecord::RecordInvalid => e
       render json: { status: 'ERROR', message: e }
     end

--- a/api/app/controllers/api/tasks_controller.rb
+++ b/api/app/controllers/api/tasks_controller.rb
@@ -3,27 +3,27 @@ module Api
     before_action :set_task, only: %i[destroy update]
 
     def index
-      @tasks = Task.all.order(id: "DESC")
+      @tasks = Task.all.order(id: 'DESC')
       render json: @tasks
     end
 
     def create
       task = Task.create!(task_param)
-      render json: { status: 'SUCCESS', message: I18n.t("errors.create_the_task"), data: task }
+      render json: { status: 'SUCCESS', message: I18n.t('message.create_the_task'), data: task }
     rescue ActiveRecord::RecordInvalid => e
       render json: { status: 'ERROR', message: e }
     end
 
     def destroy
       @task.destroy
-      render json: { status: 'SUCCESS', message: I18n.t("errors.delete_the_task"), data: @task }
+      render json: { status: 'SUCCESS', message: I18n.t('message.delete_the_task'), data: @task }
     rescue ActiveRecord::RecordInvalid => e
       render json: { status: 'ERROR', message: e }
     end
 
     def update
       @task.update!(task_param)
-      render json: { status: 'SUCCESS', message: I18n.t("errors.update_the_task"), data: @task }
+      render json: { status: 'SUCCESS', message: I18n.t('message.update_the_task'), data: @task }
     rescue ActiveRecord::RecordInvalid => e
       render json: { status: 'ERROR', message: e }
     end

--- a/api/app/controllers/api/tasks_controller.rb
+++ b/api/app/controllers/api/tasks_controller.rb
@@ -9,21 +9,21 @@ module Api
 
     def create
       task = Task.create!(task_param)
-      render json: { status: 'SUCCESS', data: task }
+      render json: { status: 'SUCCESS', message: I18n.t(:create_the_task), data: task }
     rescue ActiveRecord::RecordInvalid => e
       render json: { status: 'ERROR', message: e }
     end
 
     def destroy
       @task.destroy
-      render json: { status: 'SUCCESS', message: 'Delete the task', data: @task }
+      render json: { status: 'SUCCESS', message: I18n.t(:delete_the_task), data: @task }
     rescue ActiveRecord::RecordInvalid => e
       render json: { status: 'ERROR', message: e }
     end
 
     def update
       @task.update!(task_param)
-      render json: { status: 'SUCCESS', data: @task }
+      render json: { status: 'SUCCESS', message: I18n.t(:update_the_task), data: @task }
     rescue ActiveRecord::RecordInvalid => e
       render json: { status: 'ERROR', message: e }
     end

--- a/api/app/models/task.rb
+++ b/api/app/models/task.rb
@@ -1,3 +1,3 @@
 class Task < ApplicationRecord
-  enum status: { "not_started": 10, "in_progress": 20, "done": 30 }, _prefix: true
+  enum status: { I18n.t("status.not_started") => 10, I18n.t("status.in_progress") => 20, I18n.t("status.done") => 30 }, _prefix: true
 end

--- a/api/app/models/task.rb
+++ b/api/app/models/task.rb
@@ -1,3 +1,3 @@
 class Task < ApplicationRecord
-  enum status: { I18n.t("status.not_started") => 10, I18n.t("status.in_progress") => 20, I18n.t("status.done") => 30 }, _prefix: true
+  enum status: { I18n.t('status.not_started') => 10, I18n.t('status.in_progress') => 20, I18n.t('status.done') => 30 }, _prefix: true
 end

--- a/api/config/application.rb
+++ b/api/config/application.rb
@@ -33,5 +33,8 @@ module App
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
+    config.i18n.default_locale = :ja
   end
 end

--- a/api/config/environments/development.rb
+++ b/api/config/environments/development.rb
@@ -50,5 +50,5 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
   # host を docker コンテナの名前に合わせる
-  config.hosts << "api"
+  config.hosts << 'api'
 end

--- a/api/config/locales/ja.yml
+++ b/api/config/locales/ja.yml
@@ -3,3 +3,7 @@ ja:
     delete_the_task: "タスクが正常に削除されました"
     create_the_task: "タスクが正常に作成されました"
     update_the_task: "タスクが正常に更新されました"
+  status:
+    not_started: "未着手"
+    in_progress: "進行中"
+    done: "終了"

--- a/api/config/locales/ja.yml
+++ b/api/config/locales/ja.yml
@@ -1,0 +1,5 @@
+ja:
+  errors:
+    delete_the_task: "タスクが正常に削除されました"
+    create_the_task: "タスクが正常に作成されました"
+    update_the_task: "タスクが正常に更新されました"

--- a/api/config/locales/ja.yml
+++ b/api/config/locales/ja.yml
@@ -1,9 +1,9 @@
 ja:
   message:
-    delete_the_task: "タスクが正常に削除されました"
-    create_the_task: "タスクが正常に作成されました"
-    update_the_task: "タスクが正常に更新されました"
+    delete_the_task: 'タスクが正常に削除されました'
+    create_the_task: 'タスクが正常に作成されました'
+    update_the_task: 'タスクが正常に更新されました'
   status:
-    not_started: "未着手"
-    in_progress: "進行中"
-    done: "終了"
+    not_started: '未着手'
+    in_progress: '進行中'
+    done: '終了'

--- a/api/config/locales/ja.yml
+++ b/api/config/locales/ja.yml
@@ -1,5 +1,5 @@
 ja:
-  errors:
+  message:
     delete_the_task: "タスクが正常に削除されました"
     create_the_task: "タスクが正常に作成されました"
     update_the_task: "タスクが正常に更新されました"

--- a/front/app/package.json
+++ b/front/app/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@material-ui/core": "^4.11.4",
     "@material-ui/icons": "^4.11.2",
+    "@material-ui/lab": "^4.0.0-alpha.58",
     "axios": "^0.21.1",
     "eslint": "^7.28.0",
     "eslint-plugin-react": "^7.24.0",

--- a/front/app/pages/404.js
+++ b/front/app/pages/404.js
@@ -1,0 +1,12 @@
+import Alert from '@material-ui/lab/Alert';
+import AlertTitle from '@material-ui/lab/AlertTitle';
+
+const Custom404 = () => (
+  <Alert severity="error">
+    <AlertTitle>404</AlertTitle>
+    Page Not Found —
+    {' '}
+    <strong>ページが見つかりません</strong>
+  </Alert>
+);
+export default Custom404;

--- a/front/app/pages/500.js
+++ b/front/app/pages/500.js
@@ -1,0 +1,12 @@
+import Alert from '@material-ui/lab/Alert';
+import AlertTitle from '@material-ui/lab/AlertTitle';
+
+const Custom500 = () => (
+  <Alert severity="error">
+    <AlertTitle>500</AlertTitle>
+    Internal Server Error. —
+    {' '}
+    <strong>ページが見つかりません</strong>
+  </Alert>
+);
+export default Custom500;


### PR DESCRIPTION
## 対応step
[ステップ9: テスト(system spec)を書こう](https://github.com/KentaroYamada91011/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%979-%E3%82%A2%E3%83%97%E3%83%AA%E3%81%AE%E5%90%84%E7%A8%AE%E8%A8%AD%E5%AE%9A%E3%82%92%E8%A1%8C%E3%81%84%E3%81%BE%E3%81%97%E3%82%87%E3%81%86)
 - [ ]  日本語部分を共通化
 - [ ] タイムゾーンの設定
 - [ ] エラーページの設定
[クライアントサイドはNext.jsを使用しているためエラーページはNext.jsのエラーページを使用しました。](https://nextjs.org/docs/advanced-features/custom-error-page)

## 技術構成
- Docker
- Rails( api mode )
- Next.js
を使用している。

### バージョン
Ruby 3.0.1
Rails 6.0.3.7
MySQL 8.0

## 前提
設計についてはこちら #4 

## 修正内容
 - Rails 側のメッセージをRailsのi18nの仕組みを利用して共通化
 - Railsのタイムゾーンを日本（東京）に設定
 - Next.js 側でエラーページを作成


## 手元での確認方法
Docker にてコンテナ立ち上げ
```
$ docker-compose up --build
$ docker container ls
## rails api のリポジトリに入る
$ docker exec -i -t <api の docker のコンテナid> bash
## rails の db 作成
> rails db:create
>  rails db:seed
```
## 期待される結果
```
> rails c
# I18n.t("errors.create_the_task")
=> "タスクが正常に作成されました"
# Time.current
=> Wed, 09 Jun 2021 09:46:45 JST +09:00
```
また、存在しないURLにアクセスすると、
http://localhost:8000/1
![image](https://user-images.githubusercontent.com/45910757/121274940-88615900-c906-11eb-84f2-fea50b2972da.png)
こちらのようにエラーメッセージが表示される